### PR TITLE
fix use set more than once,will crash

### DIFF
--- a/src/stub.h
+++ b/src/stub.h
@@ -147,20 +147,32 @@ public:
         fn = addrof(addr);
         fn_stub = addrof(addr_stub);
         struct func_stub *pstub;
-        pstub = new func_stub;
-        //start
-        pstub->fn = fn;
+        std::map<char*,func_stub*>::iterator iter = m_result.find(fn);
 
-        if(distanceof(fn, fn_stub))
+        if (iter == m_result.end())
         {
-            pstub->far_jmp = true;
-            std::memcpy(pstub->code_buf, fn, CODESIZE_MAX);
+            pstub = new func_stub;
+            //start
+            pstub->fn = fn;
+
+            if(distanceof(fn, fn_stub))
+            {
+                pstub->far_jmp = true;
+                std::memcpy(pstub->code_buf, fn, CODESIZE_MAX);
+            }
+            else
+            {
+                pstub->far_jmp = false;
+                std::memcpy(pstub->code_buf, fn, CODESIZE_MIN);
+            }
         }
-        else
-        {
-            pstub->far_jmp = false;
-            std::memcpy(pstub->code_buf, fn, CODESIZE_MIN);
+        else {
+            pstub = iter->second;
+            //start
+            pstub->fn = fn;
+            pstub->far_jmp = distanceof(fn, fn_stub);
         }
+
 
 #ifdef _WIN32
         DWORD lpflOldProtect;


### PR DESCRIPTION
Fix that when using the same instance of stub, piling the same function twice, calling set (inconsistent piling functions twice), decomposing the instance of stub, or calling reset with the same instance of stub, restoring the previous function address is the function address of the first piling, not the original function address, which may cause crash and inconsistent with the expected result. Only the original address is saved every time.