### PR TITLE
Fix the problem that repeated stub the same function will cause memory leaks

### DIFF
--- a/src/stub.h
+++ b/src/stub.h
@@ -190,7 +190,16 @@ public:
         {
             throw("stub set memory protect to r+x failed");
         }
-        m_result.insert(std::pair<char*,func_stub*>(fn,pstub));
+
+        std::map<char *, func_stub *>::iterator iter = m_result.find(fn);
+        if (iter != m_result.end())
+        {
+            struct func_stub *poldstub = iter->second;
+            m_result.erase(iter);
+            delete poldstub;
+        }
+
+        m_result.insert(std::pair<char *, func_stub *>(fn, pstub));
         return;
     }
 


### PR DESCRIPTION
…y leaks

Calling set twice to the same original function will cause the func_stub object created in the first set to be out of control and not released, so may need to check before inserting the map