### PR TITLE
support to discard valgrind translation cache.

### DIFF
--- a/src/stub.h
+++ b/src/stub.h
@@ -16,7 +16,10 @@
 #include <cstring>
 //c++
 #include <map>
-
+//valgrind
+#ifdef __VALGRIND__
+#include <valgrind/valgrind.h>
+#endif
 
 #define ADDR(CLASS_NAME,MEMBER_NAME) (&CLASS_NAME::MEMBER_NAME)
 
@@ -167,10 +170,18 @@ public:
                 if(pstub->far_jmp)
                 {
                     std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+#ifdef __VALGRIND__
+                    //discard valgrind translation cache.
+                    VALGRIND_DISCARD_TRANSLATIONS(pstub->fn, CODESIZE_MAX);
+#endif
                 }
                 else
                 {
                     std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+#ifdef __VALGRIND__
+                    //discard valgrind translation cache.
+                    VALGRIND_DISCARD_TRANSLATIONS(pstub->fn, CODESIZE_MIN);
+#endif
                 }
 
 #if defined(__aarch64__) || defined(_M_ARM64)
@@ -280,10 +291,18 @@ public:
         if(pstub->far_jmp)
         {
             std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+#ifdef __VALGRIND__
+            //discard valgrind translation cache.
+            VALGRIND_DISCARD_TRANSLATIONS(pstub->fn, CODESIZE_MAX);
+#endif
         }
         else
         {
             std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+#ifdef __VALGRIND__
+            //discard valgrind translation cache.
+            VALGRIND_DISCARD_TRANSLATIONS(pstub->fn, CODESIZE_MIN);
+#endif
         }
 
 #if defined(__aarch64__) || defined(_M_ARM64)


### PR DESCRIPTION
The original function can't reenter after stub.reset when running the compiled elf with valgrind, the reason is valgrind has translated the function code after stub and saved to its code translation cache, and valgrind didn't re-translate the code after stub.reset. This code change is to support discarding valgrind code translate cache by valgrind api VALGRIND_DISCARD_TRANSLATIONS and re-translate the code after calling stub.reset, and we added self-defined macro __VALGRIND__ to enable this feature when needed(need to provide valgrind-devel to include valgrind/valgrind.h).